### PR TITLE
add test for image-file

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     },
     "scripts": {
         "build": "babel src --out-dir . --extensions '.ts'",
-        "clean": "find -E . -not -name \"jest.config.js\" -iname \"[a-z]*.js\" -maxdepth 1 -delete",
+        "clean": "find -E . -not -name \"jest.config.js\" -iname \"[a-z]*.js\" -maxdepth 1 -delete && rm -rf coverage",
         "test:coverage": "jest --collect-coverage",
         "format": "prettier --write \"{,!(node_modules)/**/}*.ts\"",
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@ccalamos/gatsby-source-googlemaps-static",
     "description": "Gatsby source plugin for Google Maps Static API",
-    "version": "1.4.7",
+    "version": "1.4.8",
     "author": "Cole Calamos <cole@colejcalamos.com>",
     "bugs": {
         "url": "https://github.com/ccalamos/gatsby-source-googlemaps-static/issues"

--- a/package.json
+++ b/package.json
@@ -52,13 +52,14 @@
     },
     "scripts": {
         "build": "babel src --out-dir . --extensions '.ts'",
-        "watch": "babel src --watch --out-dir . --ignore **/__tests__ --extensions '.ts'",
-        "format": "prettier --write \"{,!(node_modules)/**/}*.ts\"",
         "clean": "find -E . -not -name \"jest.config.js\" -iname \"[a-z]*.js\" -maxdepth 1 -delete",
+        "test:coverage": "jest --collect-coverage",
+        "format": "prettier --write \"{,!(node_modules)/**/}*.ts\"",
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+        "prepublishOnly": "cross-env NODE_ENV=production yarn run clean; cross-env NODE_ENV=production yarn run build",
         "test": "jest",
         "typecheck": "tsc --skipLibCheck --noEmit",
-        "prepublishOnly": "cross-env NODE_ENV=production yarn run clean; cross-env NODE_ENV=production yarn run build"
+        "watch": "babel src --watch --out-dir . --ignore **/__tests__ --extensions '.ts'"
     },
     "peerDependencies": {
         "gatsby": "^2.24.69"

--- a/src/__mocks__/axios.ts
+++ b/src/__mocks__/axios.ts
@@ -1,7 +1,7 @@
 // src/__mocks__/axios.ts
-import { AxiosStatic } from 'axios';
+import { AxiosStatic } from "axios";
 
-const mockAxios = jest.genMockFromModule<AxiosStatic>('axios');
+const mockAxios = jest.genMockFromModule<AxiosStatic>("axios");
 
 mockAxios.create = jest.fn(() => mockAxios);
 

--- a/src/__mocks__/axios.ts
+++ b/src/__mocks__/axios.ts
@@ -1,0 +1,8 @@
+// src/__mocks__/axios.ts
+import { AxiosStatic } from 'axios';
+
+const mockAxios = jest.genMockFromModule<AxiosStatic>('axios');
+
+mockAxios.create = jest.fn(() => mockAxios);
+
+export default mockAxios;

--- a/src/__tests__/image-file.test.ts
+++ b/src/__tests__/image-file.test.ts
@@ -1,16 +1,16 @@
-import ImageFile from '../image-file';
-import {GatsbyCache, NodePluginArgs, Store} from 'gatsby';
-import {mocked } from 'ts-jest/utils';
-import mockAxios, {AxiosResponse} from 'axios';
-import fsExtra from 'fs-extra';
+import ImageFile from "../image-file";
+import { GatsbyCache, NodePluginArgs, Store } from "gatsby";
+import { mocked } from "ts-jest/utils";
+import mockAxios, { AxiosResponse } from "axios";
+import fsExtra from "fs-extra";
 
-jest.mock('fs-extra');
+jest.mock("fs-extra");
 
-describe('image-file', () => {
+describe("image-file", () => {
     const state = {
         program: {
-            directory: '.'
-        }
+            directory: ".",
+        },
     };
 
     const store: Store = {
@@ -20,7 +20,7 @@ describe('image-file', () => {
         replaceReducer: jest.fn(),
     };
 
-    const cache: NodePluginArgs["cache"] = new class implements GatsbyCache {
+    const cache: NodePluginArgs["cache"] = new (class implements GatsbyCache {
         get(): Promise<unknown> {
             return Promise.resolve(undefined);
         }
@@ -28,9 +28,9 @@ describe('image-file', () => {
         set(): Promise<unknown> {
             return Promise.resolve(undefined);
         }
-    };
+    })();
 
-    describe('getHref', () => {
+    describe("getHref", () => {
         let params: {
             hasSecret: boolean;
             markers: string | string[];
@@ -41,16 +41,16 @@ describe('image-file', () => {
             client: string;
         };
 
-        it('with all params', async () => {
+        it("with all params", async () => {
             const axiosResponse: AxiosResponse = {
-                data: Buffer.from("jest-coverage-testing", 'utf8'),
+                data: Buffer.from("jest-coverage-testing", "utf8"),
                 status: 200,
                 statusText: "OK",
                 config: {},
-                headers: {}
+                headers: {},
             };
 
-            jest.spyOn(fsExtra, 'writeFile');
+            jest.spyOn(fsExtra, "writeFile");
 
             params = {
                 hasSecret: false,
@@ -62,12 +62,12 @@ describe('image-file', () => {
                 client: "test-client",
             };
             mocked(mockAxios.get).mockImplementationOnce(() =>
-                Promise.resolve(axiosResponse),
+                Promise.resolve(axiosResponse)
             );
 
             const imageFile = new ImageFile(cache, params);
 
-            const result = await imageFile.getHref(store, "", "")
+            const result = await imageFile.getHref(store, "", "");
 
             expect(mockAxios.get).toHaveBeenCalledTimes(1);
             expect(fsExtra.writeFile).toHaveBeenCalled();

--- a/src/cache-file.ts
+++ b/src/cache-file.ts
@@ -1,7 +1,7 @@
 import { Store, NodePluginArgs } from "gatsby";
 
 import crypto from "crypto";
-import axios, { AxiosResponse } from "axios";
+import Axios, { AxiosInstance, AxiosResponse } from "axios";
 
 import createFile from "./create-file";
 
@@ -9,6 +9,7 @@ abstract class CacheFile {
     protected _path: string | undefined;
     protected _type = "";
 
+    private _axiosClient: AxiosInstance;
     private _cache: NodePluginArgs["cache"];
 
     private _hash = "";
@@ -21,6 +22,11 @@ abstract class CacheFile {
         this.hash = hash;
 
         this.checkCache();
+
+        this._axiosClient = Axios.create({
+            method: "GET",
+            responseType: "arraybuffer",
+        });
     }
 
     protected async getPath(
@@ -57,10 +63,7 @@ abstract class CacheFile {
     }
 
     private async downloadFile(url: string): Promise<AxiosResponse> {
-        return await axios.get(url, {
-            method: "GET",
-            responseType: "arraybuffer",
-        });
+        return await this._axiosClient.get(url);
     }
 
     private set hash(newHash: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         // Target latest version of ECMAScript.
-        "target": "es2019",
+        "target": "es2020",
         // Enable strictest settings like strictNullChecks & noImplicitAny.
         "strict": true,
         // Disallow features that require cross-file information for emit.


### PR DESCRIPTION
Fixes #23 

## Proposed Changes

  - add test for image-file

I decided to take on a more complicated jest test. In order to make it work I had to make a few changes:

- set target to `es2019` to get the test to compile
- minor refactor of cache-file so that the axios response can be mocked
- add `.cache` and `.idea` to gitignore

Note that this creates a .cache directory as part of the test. I considered creating a "clean" script to package.json that looks like this: 

```
"clean": "rimraf .cache coverage",
```